### PR TITLE
:sparkles: add command

### DIFF
--- a/cli/lib/command/internal_command_settings.dart
+++ b/cli/lib/command/internal_command_settings.dart
@@ -2,9 +2,9 @@ import 'package:collection/collection.dart';
 import 'package:stax/command/internal_command.dart';
 import 'package:stax/command/types_for_internal_command.dart';
 import 'package:stax/context/context.dart';
-import 'package:stax/settings/setting.dart';
 import 'package:stax/settings/base_list_setting.dart';
 import 'package:stax/settings/key_value_list_setting.dart';
+import 'package:stax/settings/setting.dart';
 
 class InternalCommandSettings extends InternalCommand {
   late final availableSubCommands = [
@@ -29,11 +29,11 @@ class InternalCommandSettings extends InternalCommand {
   @override
   void run(final List<String> args, final Context context) {
     late final List<Setting> availableSettings = <Setting>[
+      context.settings.additionallyPull,
+      context.settings.baseBranchReplacement,
       context.settings.branchPrefix,
       context.settings.defaultBranch,
       context.settings.defaultRemote,
-      context.settings.aliases,
-      context.settings.allowedBranches,
     ].sortedBy((setting) => setting.name);
     bool isSettingAvailable(String name) =>
         availableSettings.any((setting) => setting.name == name);
@@ -42,7 +42,7 @@ class InternalCommandSettings extends InternalCommand {
     void printAvailableSettings() {
       for (final setting in availableSettings) {
         context.printToConsole(
-          " • ${setting.name} = '${setting.value}' # ${setting.description}",
+          " • ${setting.name} = '${setting.rawValue}' # ${setting.description}",
         );
       }
     }
@@ -82,14 +82,7 @@ class InternalCommandSettings extends InternalCommand {
       case ['add', final name, final value] when isSettingAvailable(name):
         final setting = getSettingByName(name);
         if (setting is KeyValueListSetting) {
-          final parts = value.split('=');
-          if (parts.length != 2) {
-            context.printToConsole(
-              "Invalid format for key-value setting. Use: key=value",
-            );
-            return;
-          }
-          setting.addKeyValue(parts[0], parts[1]);
+          setting.addRaw(value);
           context.printToConsole("Added key-value '$value' to setting: $name");
         } else if (setting is BaseListSetting) {
           setting.add(value);

--- a/cli/lib/settings/base_list_setting.dart
+++ b/cli/lib/settings/base_list_setting.dart
@@ -4,13 +4,15 @@ import 'package:stax/settings/setting.dart';
 import 'package:stax/settings/settings.dart';
 
 abstract class BaseListSetting<T> extends Setting<List<T>> {
+  T? Function(String) itemFromString;
+
   BaseListSetting(
     String name,
     List<T> defaultValue,
     Settings settings,
     String description,
-    T? Function(String) fromString,
-    String Function(T) toString,
+    this.itemFromString,
+    String Function(T) itemToString,
   ) : super(
           name,
           defaultValue,
@@ -20,7 +22,7 @@ abstract class BaseListSetting<T> extends Setting<List<T>> {
               .expand<T>(
             (element) {
               try {
-                return switch (fromString(element)) {
+                return switch (itemFromString(element)) {
                   null => [],
                   final converted => [converted],
                 };
@@ -29,7 +31,7 @@ abstract class BaseListSetting<T> extends Setting<List<T>> {
               }
             },
           ).toList(),
-          (List<T> list) => jsonEncode(list.map(toString).toList()),
+          (List<T> list) => jsonEncode(list.map(itemToString).toList()),
           description,
         );
 

--- a/cli/lib/settings/base_list_setting.dart
+++ b/cli/lib/settings/base_list_setting.dart
@@ -15,7 +15,9 @@ abstract class BaseListSetting<T> extends Setting<List<T>> {
           name,
           defaultValue,
           settings,
-          (String s) => (jsonDecode(s) as List<String>).expand<T>(
+          (String s) => (jsonDecode(s) as List<dynamic>)
+              .map((element) => element.toString())
+              .expand<T>(
             (element) {
               try {
                 return switch (fromString(element)) {

--- a/cli/lib/settings/key_value_list_setting.dart
+++ b/cli/lib/settings/key_value_list_setting.dart
@@ -20,9 +20,10 @@ class KeyValueListSetting extends BaseListSetting<MapEntry<String, String>> {
           (entry) => '${entry.key}=${entry.value}',
         );
 
-  void addKeyValue(String key, String value) {
-    removeByKey(key);
-    add(MapEntry(key, value));
+  void addRaw(String value) {
+    final parsed = itemFromString(value)!;
+    removeByKey(parsed.key);
+    add(parsed);
   }
 
   void removeByKey(String key) {

--- a/cli/lib/settings/setting.dart
+++ b/cli/lib/settings/setting.dart
@@ -17,6 +17,11 @@ class Setting<T> {
     this.description,
   );
 
+  String get rawValue => switch (_settings[name]) {
+        null => _toStringConverter(_defaultValue),
+        final raw => raw,
+      };
+
   T get value => switch (_settings[name]) {
         null => _defaultValue,
         final raw => _fromStringConverter(raw)

--- a/cli/lib/settings/settings.dart
+++ b/cli/lib/settings/settings.dart
@@ -2,9 +2,9 @@ import 'package:cli_util/cli_util.dart';
 import 'package:path/path.dart' as path;
 import 'package:stax/settings/base_settings.dart';
 import 'package:stax/settings/date_time_setting.dart';
-import 'package:stax/settings/string_setting.dart';
 import 'package:stax/settings/key_value_list_setting.dart';
 import 'package:stax/settings/string_list_setting.dart';
+import 'package:stax/settings/string_setting.dart';
 
 class Settings extends BaseSettings {
   late final DateTimeSetting lastUpdatePrompt = DateTimeSetting(
@@ -35,18 +35,20 @@ class Settings extends BaseSettings {
     'Override for default remote (empty means use first available remote)',
   );
 
-  late final KeyValueListSetting aliases = KeyValueListSetting(
-    'aliases',
+  late final KeyValueListSetting baseBranchReplacement = KeyValueListSetting(
+    'base_branch_replacement',
     [],
     this,
-    'Command aliases (e.g., "git=g")',
+    'Automatically substitute specific branch when creating pr: stable=main - '
+        'if your current branch is stable, but you want to have main is base '
+        'branch when creating PRs',
   );
 
-  late final StringListSetting allowedBranches = StringListSetting(
-    'allowed_branches',
+  late final StringListSetting additionallyPull = StringListSetting(
+    'additionally_pull',
     [],
     this,
-    'Patterns for allowed branch names (e.g., "feature/*")',
+    'Additional branches to pull besides default_branch',
   );
 
   Settings()

--- a/cli/lib/settings/settings.dart
+++ b/cli/lib/settings/settings.dart
@@ -3,6 +3,8 @@ import 'package:path/path.dart' as path;
 import 'package:stax/settings/base_settings.dart';
 import 'package:stax/settings/date_time_setting.dart';
 import 'package:stax/settings/string_setting.dart';
+import 'package:stax/settings/key_value_list_setting.dart';
+import 'package:stax/settings/string_list_setting.dart';
 
 class Settings extends BaseSettings {
   late final DateTimeSetting lastUpdatePrompt = DateTimeSetting(
@@ -31,6 +33,20 @@ class Settings extends BaseSettings {
     '',
     this,
     'Override for default remote (empty means use first available remote)',
+  );
+
+  late final KeyValueListSetting aliases = KeyValueListSetting(
+    'aliases',
+    [],
+    this,
+    'Command aliases (e.g., "git=g")',
+  );
+
+  late final StringListSetting allowedBranches = StringListSetting(
+    'allowed_branches',
+    [],
+    this,
+    'Patterns for allowed branch names (e.g., "feature/*")',
   );
 
   Settings()


### PR DESCRIPTION
Add command for add to list

I have set these 2 settings for example usage
![image](https://github.com/user-attachments/assets/92e9d261-a552-4acd-80b6-27796eb827ea)

Example usage
Adding list of strings
![image](https://github.com/user-attachments/assets/52f8865f-52ab-48f1-8c59-a428d6371e28)
Adding list of key values
![image](https://github.com/user-attachments/assets/bb417519-f26a-4ce6-aea0-9225622d3475)

Settings show to display them
![image](https://github.com/user-attachments/assets/6d1d58a9-c9b6-4809-bf2b-7b37ee0139b9)

