### PR TITLE
stax log add "--watch" flag which will continiously watch for changes in repository and will reinvoke log

### DIFF
--- a/cli/lib/command/internal_command_log.dart
+++ b/cli/lib/command/internal_command_log.dart
@@ -26,7 +26,7 @@ class InternalCommandLog extends InternalCommand {
   static final Flag watchFlag = Flag(
     short: '-w',
     long: '--watch',
-    description: 'watch all branches',
+    description: 'watch for git changes and re-run',
   );
 
   InternalCommandLog()

--- a/cli/test/cli/help_test.dart
+++ b/cli/test/cli/help_test.dart
@@ -47,6 +47,7 @@ Note: you can type first letter or couple of first letters instead of full comma
       Flags:
          -a, --all - show remote branches also
          -d, --default-branch - assume different default branch
+         -w, --watch - watch for git changes and re-run
  • move - Allows you to move around log tree. Note: you can type any amount of first letters to specify direction. 'h' instead of 'head', 't' for 'top, 'd' for down, 'u' for 'up', 'b' for 'bottom'
       Positional arguments:
          [arg]+ - up (one up, optionally you can provide followup argument which would be a 0-based index of the child you want to move, by default it is 0), down (one down), top (to the closest top parent that have at least two children or to the top most node, optionally you can provide followup argument which would be a 0-based index of the child you want to move, by default it is 0), bottom (to the closest bottom parent that have at least two children or bottom most node, will stop before any direct parent of <remote>/head), head (<remote>/head)


### PR DESCRIPTION
note: clear terminal is not working in windows powershell & cmd. but it works in windows git bash shell. 
found this issue in dart sdk they saying windows by default doesn't support clear and need to call some windows api.
https://github.com/dart-lang/sdk/issues/48953

closes: https://github.com/TarasMazepa/stax/issues/519