### PR TITLE
Include LICENSE.txt and VERIFICATION.txt in appropriate format

### DIFF
--- a/.github/scripts/prepare-chocolatey.ps1
+++ b/.github/scripts/prepare-chocolatey.ps1
@@ -24,6 +24,9 @@ $licenseContent
 "@
 $formattedLicense | Out-File -FilePath "$ToolsPath\LICENSE.txt" -Encoding UTF8
 
+# Calculate checksum of the downloaded zip file
+$checksumHash = (Get-FileHash -Path $outputZip -Algorithm SHA256).Hash
+
 # Create VERIFICATION.txt file (CPMR0006 requirement)
 Write-Host "Creating VERIFICATION.txt in $ToolsPath"
 $verificationContent = @"
@@ -42,15 +45,11 @@ Package can be verified like this:
    - Use Chocolatey utility 'checksum.exe'
 
    checksum type: sha256
-   checksum: [CHECKSUM_PLACEHOLDER]
+   checksum: $checksumHash
 
 File 'LICENSE.txt' is obtained from:
    https://github.com/TarasMazepa/stax/blob/main/LICENSE
 "@
-
-# Calculate checksum of the downloaded zip file
-$checksum = Get-FileHash -Path $outputZip -Algorithm SHA256
-$verificationContent = $verificationContent -replace '\[CHECKSUM_PLACEHOLDER\]', $checksum.Hash
 
 # Write verification file
 $verificationContent | Out-File -FilePath "$ToolsPath\VERIFICATION.txt" -Encoding UTF8

--- a/.github/scripts/prepare-chocolatey.ps1
+++ b/.github/scripts/prepare-chocolatey.ps1
@@ -11,4 +11,46 @@ Invoke-WebRequest -Uri $downloadUrl -OutFile $outputZip
 $ToolsPath = "chocolatey/stax/tools"
 Write-Host "Extracting stax.exe to $ToolsPath"
 Expand-Archive -Path $outputZip -DestinationPath "$ToolsPath" -Force
-Copy-Item "LICENSE" -Destination $ToolsPath
+
+# Create LICENSE.txt file with proper Chocolatey format (CPMR0005 requirement)
+Write-Host "Creating LICENSE.txt in $ToolsPath"
+$licenseContent = Get-Content "LICENSE" -Raw
+$formattedLicense = @"
+From: https://github.com/TarasMazepa/stax/blob/main/LICENSE
+
+LICENSE
+
+$licenseContent
+"@
+$formattedLicense | Out-File -FilePath "$ToolsPath\LICENSE.txt" -Encoding UTF8
+
+# Create VERIFICATION.txt file (CPMR0006 requirement)
+Write-Host "Creating VERIFICATION.txt in $ToolsPath"
+$verificationContent = @"
+VERIFICATION
+
+Verification is intended to assist the Chocolatey moderators and community
+in verifying that this package's contents are trustworthy.
+
+Package can be verified like this:
+
+1. Download the binary from the official GitHub release:
+   $downloadUrl
+
+2. You can use one of the following methods to obtain the checksum:
+   - Use powershell function 'Get-FileHash'
+   - Use Chocolatey utility 'checksum.exe'
+
+   checksum type: sha256
+   checksum: [CHECKSUM_PLACEHOLDER]
+
+File 'LICENSE.txt' is obtained from:
+   https://github.com/TarasMazepa/stax/blob/main/LICENSE
+"@
+
+# Calculate checksum of the downloaded zip file
+$checksum = Get-FileHash -Path $outputZip -Algorithm SHA256
+$verificationContent = $verificationContent -replace '\[CHECKSUM_PLACEHOLDER\]', $checksum.Hash
+
+# Write verification file
+$verificationContent | Out-File -FilePath "$ToolsPath\VERIFICATION.txt" -Encoding UTF8


### PR DESCRIPTION
- Make sure the copied license file is named `LICENSE.txt`
- Make sure the license file starts with expected `From: <url>`
- Generate simple `VERIFICATION.txt` adhering to template from `choco new test`
- Include auto-generated checksum in the verification steps

Closes #750 