### PR TITLE
Rename --loud flag to --verbose with -v shorthand (#751)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+0.10.11
+ * --loud -> --verbose - renaming global flag to conform with other commandline tools, adds -v shorthand
+ 
 0.10.10
  * stax delete -> stax delete-stale - renaming delete to delete-stale
  * --silent -> --quiet - renaming global flag to conform with other commandline tools, adds -q shorthand
- * --loud -> --verbose - renaming global flag to conform with other commandline tools, adds -v shorthand
  * stax delete-stale - fix case when remote and local branches have different names and stax delete-stale wouldn't recognize that branches as gone due to overly strict parsing
 
 0.10.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.10.10
  * stax delete -> stax delete-stale - renaming delete to delete-stale
- * --silent -> --quiet - renaming global flag to conform with other commandline tools
+ * --silent -> --quiet - renaming global flag to conform with other commandline tools, adds -q shorthand
+ * --loud -> --verbose - renaming global flag to conform with other commandline tools, adds -v shorthand
  * stax delete-stale - fix case when remote and local branches have different names and stax delete-stale wouldn't recognize that branches as gone due to overly strict parsing
 
 0.10.9

--- a/cli/lib/context/context.dart
+++ b/cli/lib/context/context.dart
@@ -13,7 +13,7 @@ import 'package:stax/settings/settings.dart';
 class Context {
   final bool quiet;
   final String? workingDirectory;
-  final bool forcedLoudness;
+  final bool forcedVerbosity;
   final bool acceptAll;
   final bool declineAll;
 
@@ -33,7 +33,7 @@ class Context {
   Context(
     this.quiet,
     this.workingDirectory,
-    this.forcedLoudness,
+    this.forcedVerbosity,
     this.acceptAll,
     this.declineAll,
   );
@@ -47,18 +47,18 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedLoudness,
+      forcedVerbosity,
       acceptAll,
       declineAll,
     );
   }
 
-  Context withForcedLoudness(bool forcedLoudness) {
-    if (this.forcedLoudness == forcedLoudness) return this;
+  Context withForcedVerbosity(bool forcedVerbosity) {
+    if (this.forcedVerbosity == forcedVerbosity) return this;
     return Context(
       quiet,
       workingDirectory,
-      forcedLoudness,
+      forcedVerbosity,
       acceptAll,
       declineAll,
     );
@@ -69,7 +69,7 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedLoudness,
+      forcedVerbosity,
       acceptAll,
       declineAll,
     );
@@ -88,7 +88,7 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedLoudness,
+      forcedVerbosity,
       acceptAll,
       declineAll,
     );
@@ -99,14 +99,14 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedLoudness,
+      forcedVerbosity,
       acceptAll,
       declineAll,
     );
   }
 
   bool shouldBeQuiet() {
-    return !forcedLoudness && quiet;
+    return !forcedVerbosity && quiet;
   }
 
   void printToConsole(Object? object) {

--- a/cli/lib/context/context.dart
+++ b/cli/lib/context/context.dart
@@ -13,7 +13,7 @@ import 'package:stax/settings/settings.dart';
 class Context {
   final bool quiet;
   final String? workingDirectory;
-  final bool forcedVerbosity;
+  final bool verbose;
   final bool acceptAll;
   final bool declineAll;
 
@@ -33,7 +33,7 @@ class Context {
   Context(
     this.quiet,
     this.workingDirectory,
-    this.forcedVerbosity,
+    this.verbose,
     this.acceptAll,
     this.declineAll,
   );
@@ -47,18 +47,18 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedVerbosity,
+      verbose,
       acceptAll,
       declineAll,
     );
   }
 
-  Context withForcedVerbosity(bool forcedVerbosity) {
-    if (this.forcedVerbosity == forcedVerbosity) return this;
+  Context withVerbose(bool verbose) {
+    if (this.verbose == verbose) return this;
     return Context(
       quiet,
       workingDirectory,
-      forcedVerbosity,
+      verbose,
       acceptAll,
       declineAll,
     );
@@ -69,7 +69,7 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedVerbosity,
+      verbose,
       acceptAll,
       declineAll,
     );
@@ -88,7 +88,7 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedVerbosity,
+      verbose,
       acceptAll,
       declineAll,
     );
@@ -99,14 +99,14 @@ class Context {
     return Context(
       quiet,
       workingDirectory,
-      forcedVerbosity,
+      verbose,
       acceptAll,
       declineAll,
     );
   }
 
   bool shouldBeQuiet() {
-    return !forcedVerbosity && quiet;
+    return !verbose && quiet;
   }
 
   void printToConsole(Object? object) {

--- a/cli/lib/context/context_handle_global_flags.dart
+++ b/cli/lib/context/context_handle_global_flags.dart
@@ -7,8 +7,9 @@ extension ContextHandleGlobalFlags on Context {
     long: '--quiet',
     description: 'Removes all output except user prompts.',
   );
-  static final loudFlag = Flag(
-    long: '--loud',
+  static final verboseFlag = Flag(
+    short: '-v',
+    long: '--verbose',
     description: 'Force all the output.',
   );
   static final acceptAllFlag = Flag(
@@ -27,7 +28,7 @@ extension ContextHandleGlobalFlags on Context {
 
   static final List<Flag> flags = [
     quietFlag,
-    loudFlag,
+    verboseFlag,
     acceptAllFlag,
     declineAllFlag,
     helpFlag,
@@ -35,7 +36,7 @@ extension ContextHandleGlobalFlags on Context {
 
   Context handleGlobalFlags(List<String> args) {
     return withQuiet(quietFlag.hasFlag(args))
-        .withForcedLoudness(loudFlag.hasFlag(args))
+        .withForcedVerbosity(verboseFlag.hasFlag(args))
         .withAcceptingAll(acceptAllFlag.hasFlag(args))
         .withDecliningAll(declineAllFlag.hasFlag(args));
   }

--- a/cli/lib/context/context_handle_global_flags.dart
+++ b/cli/lib/context/context_handle_global_flags.dart
@@ -36,7 +36,7 @@ extension ContextHandleGlobalFlags on Context {
 
   Context handleGlobalFlags(List<String> args) {
     return withQuiet(quietFlag.hasFlag(args))
-        .withForcedVerbosity(verboseFlag.hasFlag(args))
+        .withVerbose(verboseFlag.hasFlag(args))
         .withAcceptingAll(acceptAllFlag.hasFlag(args))
         .withDecliningAll(declineAllFlag.hasFlag(args));
   }

--- a/cli/test/cli/help_test.dart
+++ b/cli/test/cli/help_test.dart
@@ -10,8 +10,8 @@ void main() {
    --accept-all - Accept all the user prompts automatically.
    --decline-all - Decline all the user prompts automatically.
    -h, --help - Shows help documentation for the command
-   -v, --verbose - Force all the output.
    -q, --quiet - Removes all output except user prompts.
+   -v, --verbose - Force all the output.
 Here are available commands:
 Note: you can type first letter or couple of first letters instead of full command name. 'c' for 'commit' or 'am' for 'amend'.
  • about - Shows information about the stax.

--- a/cli/test/cli/help_test.dart
+++ b/cli/test/cli/help_test.dart
@@ -10,7 +10,7 @@ void main() {
    --accept-all - Accept all the user prompts automatically.
    --decline-all - Decline all the user prompts automatically.
    -h, --help - Shows help documentation for the command
-   --loud - Force all the output.
+   -v, --verbose - Force all the output.
    -q, --quiet - Removes all output except user prompts.
 Here are available commands:
 Note: you can type first letter or couple of first letters instead of full command name. 'c' for 'commit' or 'am' for 'amend'.

--- a/cli/test/context/context_test.dart
+++ b/cli/test/context/context_test.dart
@@ -6,7 +6,7 @@ void main() {
     final context = Context.implicit();
     expect(context.quiet, false);
     expect(context.workingDirectory, null);
-    expect(context.forcedLoudness, false);
+    expect(context.forcedVerbosity, false);
     expect(context.acceptAll, false);
     expect(context.declineAll, false);
   });
@@ -14,7 +14,7 @@ void main() {
     final context = Context(true, 'directory', true, true, true);
     expect(context.quiet, true);
     expect(context.workingDirectory, 'directory');
-    expect(context.forcedLoudness, true);
+    expect(context.forcedVerbosity, true);
     expect(context.acceptAll, true);
     expect(context.declineAll, true);
   });
@@ -28,9 +28,9 @@ void main() {
     Context modifiedContext = context.withWorkingDirectory(null);
     expect(context, (c) => identical(c, modifiedContext));
   });
-  test('implicit not changing withForcedLoudness', () {
+  test('implicit not changing withForcedVerbosity', () {
     final context = Context.implicit();
-    Context modifiedContext = context.withForcedLoudness(false);
+    Context modifiedContext = context.withForcedVerbosity(false);
     expect(context, (c) => identical(c, modifiedContext));
   });
   test('explicit not changing withQuiet', () {
@@ -43,9 +43,9 @@ void main() {
     Context modifiedContext = context.withWorkingDirectory('directory');
     expect(context, (c) => identical(c, modifiedContext));
   });
-  test('explicit not changing withForcedLoudness', () {
+  test('explicit not changing withForcedVerbosity', () {
     final context = Context(true, 'directory', true, true, true);
-    Context modifiedContext = context.withForcedLoudness(true);
+    Context modifiedContext = context.withForcedVerbosity(true);
     expect(context, (c) => identical(c, modifiedContext));
   });
   test('implicit changing withQuiet', () {
@@ -62,12 +62,12 @@ void main() {
     expect(context.workingDirectory, null);
     expect(modifiedContext.workingDirectory, 'directory');
   });
-  test('implicit changing withForcedLoudness', () {
+  test('implicit changing withForcedVerbosity', () {
     final context = Context.implicit();
-    Context modifiedContext = context.withForcedLoudness(true);
+    Context modifiedContext = context.withForcedVerbosity(true);
     expect(context, (c) => !identical(c, modifiedContext));
-    expect(context.forcedLoudness, false);
-    expect(modifiedContext.forcedLoudness, true);
+    expect(context.forcedVerbosity, false);
+    expect(modifiedContext.forcedVerbosity, true);
   });
   test('explicit changing withQuiet', () {
     final context = Context(true, 'directory', true, true, true);
@@ -83,11 +83,11 @@ void main() {
     expect(context.workingDirectory, 'directory');
     expect(modifiedContext.workingDirectory, null);
   });
-  test('explicit changing withForcedLoudness', () {
+  test('explicit changing withForcedVerbosity', () {
     final context = Context(true, 'directory', true, true, true);
-    Context modifiedContext = context.withForcedLoudness(false);
+    Context modifiedContext = context.withForcedVerbosity(false);
     expect(context, (c) => !identical(c, modifiedContext));
-    expect(context.forcedLoudness, true);
-    expect(modifiedContext.forcedLoudness, false);
+    expect(context.forcedVerbosity, true);
+    expect(modifiedContext.forcedVerbosity, false);
   });
 }

--- a/cli/test/context/context_test.dart
+++ b/cli/test/context/context_test.dart
@@ -6,7 +6,7 @@ void main() {
     final context = Context.implicit();
     expect(context.quiet, false);
     expect(context.workingDirectory, null);
-    expect(context.forcedVerbosity, false);
+    expect(context.verbose, false);
     expect(context.acceptAll, false);
     expect(context.declineAll, false);
   });
@@ -14,7 +14,7 @@ void main() {
     final context = Context(true, 'directory', true, true, true);
     expect(context.quiet, true);
     expect(context.workingDirectory, 'directory');
-    expect(context.forcedVerbosity, true);
+    expect(context.verbose, true);
     expect(context.acceptAll, true);
     expect(context.declineAll, true);
   });
@@ -28,9 +28,9 @@ void main() {
     Context modifiedContext = context.withWorkingDirectory(null);
     expect(context, (c) => identical(c, modifiedContext));
   });
-  test('implicit not changing withForcedVerbosity', () {
+  test('implicit not changing withVerbose', () {
     final context = Context.implicit();
-    Context modifiedContext = context.withForcedVerbosity(false);
+    Context modifiedContext = context.withVerbose(false);
     expect(context, (c) => identical(c, modifiedContext));
   });
   test('explicit not changing withQuiet', () {
@@ -43,9 +43,9 @@ void main() {
     Context modifiedContext = context.withWorkingDirectory('directory');
     expect(context, (c) => identical(c, modifiedContext));
   });
-  test('explicit not changing withForcedVerbosity', () {
+  test('explicit not changing withVerbose', () {
     final context = Context(true, 'directory', true, true, true);
-    Context modifiedContext = context.withForcedVerbosity(true);
+    Context modifiedContext = context.withVerbose(true);
     expect(context, (c) => identical(c, modifiedContext));
   });
   test('implicit changing withQuiet', () {
@@ -62,12 +62,12 @@ void main() {
     expect(context.workingDirectory, null);
     expect(modifiedContext.workingDirectory, 'directory');
   });
-  test('implicit changing withForcedVerbosity', () {
+  test('implicit changing withVerbose', () {
     final context = Context.implicit();
-    Context modifiedContext = context.withForcedVerbosity(true);
+    Context modifiedContext = context.withVerbose(true);
     expect(context, (c) => !identical(c, modifiedContext));
-    expect(context.forcedVerbosity, false);
-    expect(modifiedContext.forcedVerbosity, true);
+    expect(context.verbose, false);
+    expect(modifiedContext.verbose, true);
   });
   test('explicit changing withQuiet', () {
     final context = Context(true, 'directory', true, true, true);
@@ -83,11 +83,11 @@ void main() {
     expect(context.workingDirectory, 'directory');
     expect(modifiedContext.workingDirectory, null);
   });
-  test('explicit changing withForcedVerbosity', () {
+  test('explicit changing withVerbose', () {
     final context = Context(true, 'directory', true, true, true);
-    Context modifiedContext = context.withForcedVerbosity(false);
+    Context modifiedContext = context.withVerbose(false);
     expect(context, (c) => !identical(c, modifiedContext));
-    expect(context.forcedVerbosity, true);
-    expect(modifiedContext.forcedVerbosity, false);
+    expect(context.verbose, true);
+    expect(modifiedContext.verbose, false);
   });
 }


### PR DESCRIPTION
* Rename `--loud` to `--verbose` and add `-v` shorthand
* Propagate `loud` -> `verbose` throughout codebase and docs

Follows same pattern as #775 (`--silent` to `--quiet`) to conform with standard CLI conventions.
Closes #751 