### PR TITLE
🧪 Add edge case test for getPullRequestUrl with missing remote

### DIFF
--- a/cli/test/context/context_get_pull_request_url_test.dart
+++ b/cli/test/context/context_get_pull_request_url_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+import 'package:stax/context/context.dart';
+import 'package:stax/context/context_get_pull_request_url.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('returns null when remote is missing', () {
+    final tempDir = Directory.systemTemp.createTempSync('stax_test_');
+    try {
+      final context = Context.implicit().withWorkingDirectory(tempDir.path);
+      context.command(['git', 'init']).runSync();
+
+      final url = context.getPullRequestUrl('main', 'feature');
+      expect(url, isNull);
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+
+  test('returns expected URL when remote is present', () {
+    final tempDir = Directory.systemTemp.createTempSync('stax_test_');
+    try {
+      final context = Context.implicit().withWorkingDirectory(tempDir.path);
+      context.command(['git', 'init']).runSync();
+      context.command(['git', 'remote', 'add', 'origin', 'git@github.com:example/repo.git']).runSync();
+
+      final url = context.getPullRequestUrl('main', 'feature');
+      expect(url, 'https://github.com/example/repo/compare/main...feature?expand=1');
+    } finally {
+      tempDir.deleteSync(recursive: true);
+    }
+  });
+}

--- a/cli/test/context/context_get_pull_request_url_test.dart
+++ b/cli/test/context/context_get_pull_request_url_test.dart
@@ -22,10 +22,19 @@ void main() {
     try {
       final context = Context.implicit().withWorkingDirectory(tempDir.path);
       context.command(['git', 'init']).runSync();
-      context.command(['git', 'remote', 'add', 'origin', 'git@github.com:example/repo.git']).runSync();
+      context.command([
+        'git',
+        'remote',
+        'add',
+        'origin',
+        'git@github.com:example/repo.git',
+      ]).runSync();
 
       final url = context.getPullRequestUrl('main', 'feature');
-      expect(url, 'https://github.com/example/repo/compare/main...feature?expand=1');
+      expect(
+        url,
+        'https://github.com/example/repo/compare/main...feature?expand=1',
+      );
     } finally {
       tempDir.deleteSync(recursive: true);
     }


### PR DESCRIPTION
🎯 **What:** The testing gap for `getPullRequestUrl` method inside `ContextGetPullRequestUrl` extension was addressed. Specifically, it lacked coverage for the scenario when a Git remote is missing.
📊 **Coverage:** A new test file `cli/test/context/context_get_pull_request_url_test.dart` was added. It covers:
- The edge case when a repository has no remote configured, properly validating that `getPullRequestUrl` returns `null`.
- The happy path when a remote is correctly configured.
✨ **Result:** Test coverage for `getPullRequestUrl` is improved and we now have safeguards to ensure it handles the missing remote gracefully without exceptions.

---
*PR created automatically by Jules for task [15415019405168072794](https://jules.google.com/task/15415019405168072794) started by @TarasMazepa*