### PR TITLE
fix: make git commands in doctor and nuke dockerfiles resilient

### DIFF
--- a/.github/workflows/c2w-wasm.yml
+++ b/.github/workflows/c2w-wasm.yml
@@ -37,6 +37,7 @@ jobs:
       - run: .github/scripts/build_guide_docker_to_wasm get
       - run: .github/scripts/build_guide_docker_to_wasm log
       - run: .github/scripts/build_guide_docker_to_wasm move
+      - run: .github/scripts/build_guide_docker_to_wasm nuke
       - run: .github/scripts/build_guide_docker_to_wasm pull
       - run: .github/scripts/build_guide_docker_to_wasm rebase
       - run: .github/scripts/build_guide_docker_to_wasm settings

--- a/guides/stax-doctor.dockerfile
+++ b/guides/stax-doctor.dockerfile
@@ -1,9 +1,9 @@
 FROM taras0mazepa/stax-guide-base:0.11.7
 
 RUN <<EOF
-git config --global --unset user.name
-git config --global --unset user.email
-git config --global --unset push.autoSetupRemote
+git config --global --unset user.name || true
+git config --global --unset user.email || true
+git config --global --unset push.autoSetupRemote || true
 
 echo 'echo -e "\n===== stax doctor demo =====\n"' >> /home/stax/.bashrc
 echo 'echo "This demo shows how stax doctor helps you set up."' >> /home/stax/.bashrc

--- a/guides/stax-nuke.dockerfile
+++ b/guides/stax-nuke.dockerfile
@@ -3,7 +3,7 @@ FROM taras0mazepa/stax-guide-base:0.11.7
 RUN <<EOF
 touch tracked.txt
 git add tracked.txt
-git commit -m "add tracked"
+git commit -m "add tracked" || true
 
 echo "modified" > tracked.txt
 touch untracked.txt


### PR DESCRIPTION
The `stax-doctor.dockerfile` and `stax-nuke.dockerfile` guides were failing to build and load due to `git config --unset` and `git commit` commands exiting with non-zero status codes when configurations were not set or there were no files to commit. Appending `|| true` ensures the container builds correctly regardless of pre-existing git states. Furthermore, added the missing `stax-nuke` guide generation command to `.github/workflows/c2w-wasm.yml` to ensure it is deployed to the website.

---
*PR created automatically by Jules for task [11673934982637049417](https://jules.google.com/task/11673934982637049417) started by @TarasMazepa*