### PR TITLE
Add e2e benchmark for repositories with many merge commits

### DIFF
--- a/cli/test/e2e/rebase_many_merge_commits_test.dart
+++ b/cli/test/e2e/rebase_many_merge_commits_test.dart
@@ -1,0 +1,54 @@
+import 'package:test/test.dart';
+
+import '../e2e_repository.dart';
+import 'base/e2e_group.dart';
+
+const int mergeCommitCount = 300;
+
+const String expectedRepository = '/repo-expected';
+
+const String stackTipBranch = 'feature-two';
+
+void main() {
+  e2eGroup(
+    'rebase with many merge commits',
+    timeout: const Timeout(Duration(minutes: 5)),
+    (setup) {
+      test('main is built out of merge commits', () async {
+        final result = await setup.run('git', [
+          '-C',
+          defaultRepositoryPath,
+          'rev-list',
+          '--count',
+          '--merges',
+          'origin/main',
+        ]);
+
+        expect(int.parse((result.stdout as String).trim()), mergeCommitCount);
+      });
+
+      test('rebases stack onto main', () async {
+        final stopwatch = Stopwatch()..start();
+        final result = await setup.runStax(['rebase']);
+        stopwatch.stop();
+
+        expect(
+          result.exitCode,
+          0,
+          reason: 'stax rebase failed: ${result.stderr}',
+        );
+        print(
+          'stax rebase over $mergeCommitCount merge commits '
+          'took ${stopwatch.elapsed.inMilliseconds}ms',
+        );
+
+        await expectSameRepositoryHistory(
+          setup.run,
+          expected: expectedRepository,
+          revisions: const [stackTipBranch],
+        );
+        await expectCleanRepositoryFiles(setup.run);
+      });
+    },
+  );
+}

--- a/cli/test/e2e/rebase_many_merge_commits_test.dockerfile
+++ b/cli/test/e2e/rebase_many_merge_commits_test.dockerfile
@@ -1,0 +1,63 @@
+FROM stax-e2e-test:latest
+
+RUN <<EOF
+set -e
+
+git config --global user.email stax@example.com
+git config --global user.name stax
+git config --global init.defaultBranch main
+
+git init --quiet --bare /origin
+
+git clone --quiet /origin /repo
+cd /repo
+echo main > main.txt
+echo side 0 > side.txt
+git add .
+git commit --quiet -m "initial commit"
+git push --quiet --set-upstream origin main
+
+# Stack of two branches rooted at the initial commit, so that a rebase onto the
+# updated main actually has work to do.
+git checkout --quiet -b feature-one
+echo one > one.txt
+git add .
+git commit --quiet -m "feature one"
+git push --quiet --set-upstream origin feature-one
+
+git checkout --quiet -b feature-two
+echo two > two.txt
+git add .
+git commit --quiet -m "feature two"
+git push --quiet --set-upstream origin feature-two
+
+# Grow main with a lot of merge commits. Every side branch rewrites the same
+# file, so the merge back into main is always conflict free. Side branches are
+# deleted right after they are merged, so the repository ends up with many merge
+# commits rather than with many refs.
+git checkout --quiet main
+i=1
+while [ "$i" -le 300 ]; do
+  git checkout --quiet -b "side-$i" main
+  echo "side $i" > side.txt
+  git commit --quiet --all -m "side $i"
+  git checkout --quiet main
+  git merge --quiet --no-ff -m "merge side $i" "side-$i"
+  git branch --quiet --delete "side-$i"
+  i=$((i + 1))
+done
+git push --quiet origin main
+git remote set-head origin --auto
+
+git checkout --quiet feature-one
+
+# Ground truth built with plain git, used to assert what stax rebase produced.
+git clone --quiet /origin /repo-expected
+cd /repo-expected
+git checkout --quiet -b feature-one origin/feature-one
+git rebase --quiet origin/main
+git checkout --quiet -b feature-two origin/feature-two
+git rebase --quiet --onto feature-one origin/feature-one
+EOF
+
+WORKDIR /repo


### PR DESCRIPTION
- Add an e2e benchmark covering a repository with many merge commits.
- Verify `stax rebase` against a plain Git rebase result.
- Reuse the repository assertion helpers for validation.
- Report execution time to help benchmark future rebase changes.