### PR TITLE
Update monolib_dart to 0.0.31 and fix breaking changes

### DIFF
--- a/cli/lib/command/internal_command_doctor.dart
+++ b/cli/lib/command/internal_command_doctor.dart
@@ -225,7 +225,7 @@ class InternalCommandDoctor extends InternalCommand {
     }();
 
     if (isJson) {
-      await jsonEncodeAsync({
+      await jsonEncodeAsync(object: {
         'checks': checksStream.map(
           (result) => {
             'successful': result.successful,
@@ -235,7 +235,7 @@ class InternalCommandDoctor extends InternalCommand {
             'resolution': ?result.resolution,
           },
         ),
-      }, stdout);
+      }, sink: stdout);
       return;
     }
     await for (final result in checksStream) {

--- a/cli/lib/command/internal_command_doctor.dart
+++ b/cli/lib/command/internal_command_doctor.dart
@@ -225,17 +225,20 @@ class InternalCommandDoctor extends InternalCommand {
     }();
 
     if (isJson) {
-      await jsonEncodeAsync(object: {
-        'checks': checksStream.map(
-          (result) => {
-            'successful': result.successful,
-            'name': result.name,
-            'result': result.result,
-            'error': ?result.error,
-            'resolution': ?result.resolution,
-          },
-        ),
-      }, sink: stdout);
+      await jsonEncodeAsync(
+        object: {
+          'checks': checksStream.map(
+            (result) => {
+              'successful': result.successful,
+              'name': result.name,
+              'result': result.result,
+              'error': ?result.error,
+              'resolution': ?result.resolution,
+            },
+          ),
+        },
+        sink: stdout,
+      );
       return;
     }
     await for (final result in checksStream) {

--- a/cli/lib/commit_tree_for_test_case.dart
+++ b/cli/lib/commit_tree_for_test_case.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:collection/collection.dart';
 import 'package:monolib_dart/monolib_dart.dart';
+import 'package:collection/collection.dart';
 import 'package:stax/log/decorated/decorated_log_line_producer.dart';
 
 class CommitTreeForTestCase implements DecoratedLogLineProducerAdapter<int> {
@@ -223,8 +223,8 @@ class CommitTreeForTestCase implements DecoratedLogLineProducerAdapter<int> {
     return _children(id).sorted(
       (a, b) =>
           isDefaultBranchOrHasDefaultBranchAsAChild(
-            a,
-          ).compareChainReverse(isDefaultBranchOrHasDefaultBranchAsAChild(b)) ??
+            b,
+          ).compareChain(isDefaultBranchOrHasDefaultBranchAsAChild(a)) ??
           branchName(b).compareTo(branchName(a)),
     );
   }

--- a/cli/lib/context/context_git_log_all.dart
+++ b/cli/lib/context/context_git_log_all.dart
@@ -153,7 +153,7 @@ class GitLogAllNode {
   ) {
     return children.sorted(
       (a, b) =>
-          isPartOfMainBranch(a).compareChainReverse(isPartOfMainBranch(b)) ??
+          isPartOfMainBranch(b).compareChain(isPartOfMainBranch(a)) ??
           b.line.branchNameOrCommitHash().compareChain(
             a.line.branchNameOrCommitHash(),
           ) ??

--- a/cli/lib/external_command/external_command.dart
+++ b/cli/lib/external_command/external_command.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:monolib_dart/monolib_dart.dart';
 import 'package:stax/context/context.dart';
 import 'package:stax/external_command/extended_process_result.dart';
 import 'package:stax/external_command/on_process_result.dart';
@@ -106,7 +105,7 @@ class ExternalCommand {
     ].wait;
     String Function(dynamic d) joinStringList = onDemandPrint
         ? (x) => ''
-        : (x) => x.join();
+        : (x) => (x as List<String>).join();
     return ProcessResult(
       process.pid,
       resultParts[0] as int,
@@ -160,5 +159,15 @@ class ExternalCommand {
   @override
   String toString() {
     return _parts.map((e) => e.contains(' ') ? '"$e"' : e).join(' ');
+  }
+}
+extension _RemoveEndingNewLine on String {
+  String removeEndingNewLine() {
+    if (endsWith('\r\n')) {
+      return substring(0, length - 2);
+    } else if (endsWith('\n')) {
+      return substring(0, length - 1);
+    }
+    return this;
   }
 }

--- a/cli/lib/external_command/external_command.dart
+++ b/cli/lib/external_command/external_command.dart
@@ -161,6 +161,7 @@ class ExternalCommand {
     return _parts.map((e) => e.contains(' ') ? '"$e"' : e).join(' ');
   }
 }
+
 extension _RemoveEndingNewLine on String {
   String removeEndingNewLine() {
     if (endsWith('\r\n')) {

--- a/cli/lib/settings/preferences.dart
+++ b/cli/lib/settings/preferences.dart
@@ -22,6 +22,6 @@ class Preferences extends KeyValueStore {
 
   Preferences()
     : super.fromPath(
-        path.join(applicationConfigHome('stax'), '.stax_preferences'),
+        path.join(BaseDirectories('stax').configHome, '.stax_preferences'),
       );
 }

--- a/cli/lib/settings/settings.dart
+++ b/cli/lib/settings/settings.dart
@@ -5,5 +5,7 @@ import 'package:stax/settings/key_value_store.dart';
 
 class Settings extends KeyValueStore with BaseSettings {
   Settings()
-    : super.fromPath(path.join(BaseDirectories('stax').configHome, '.stax_config'));
+    : super.fromPath(
+        path.join(BaseDirectories('stax').configHome, '.stax_config'),
+      );
 }

--- a/cli/lib/settings/settings.dart
+++ b/cli/lib/settings/settings.dart
@@ -5,5 +5,5 @@ import 'package:stax/settings/key_value_store.dart';
 
 class Settings extends KeyValueStore with BaseSettings {
   Settings()
-    : super.fromPath(path.join(applicationConfigHome('stax'), '.stax_config'));
+    : super.fromPath(path.join(BaseDirectories('stax').configHome, '.stax_config'));
 }

--- a/cli/pubspec.lock
+++ b/cli/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: "direct main"
     description:
       name: cli_util
-      sha256: "5909d2c6b66817222779e1eedc19e0e28b76d1df7bd9856a4792ccb9881df358"
+      sha256: "71e43f1976c3eae2d9468a5b4d6600bf8cae61508b87f27fa1799228935d48ab"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.5.2"
   collection:
     dependency: "direct main"
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: monolib_dart
-      sha256: d0355a25d70735dc5a8e754867a81766486707441f069607c3be0fb1d51b3a0c
+      sha256: "25effd816448555e9fb8dca3937a4bf775a176c70137a0fbd885adfdb80f39e8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.26"
+    version: "0.0.31"
   node_preamble:
     dependency: transitive
     description:

--- a/cli/pubspec.yaml
+++ b/cli/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   collection: ^1.19.1
   http: ^1.6.0
   characters: ^1.4.1
-  monolib_dart: ^0.0.17
+  monolib_dart: ^0.0.31
 
 dev_dependencies:
   lints: ^6.1.0

--- a/cli/test/e2e_interactive/docker/interactive_stax_session.dart
+++ b/cli/test/e2e_interactive/docker/interactive_stax_session.dart
@@ -60,9 +60,10 @@ class InteractiveStaxSession {
   }) async {
     final current = _accumulated.toString();
     if (current.contains(pattern)) return current;
-    if (_output.isClosed)
+    if (_output.isClosed) {
       throw StateError('Session closed before "$pattern" appeared.');
-    return await _output.stream
+    }
+    return _output.stream
         .map((_) => _accumulated.toString())
         .firstWhere((s) => s.contains(pattern))
         .timeout(


### PR DESCRIPTION
Bumps `monolib_dart` dependency from `^0.0.17` to `^0.0.31` and addresses all resulting breaking API changes, deprecations, and static analysis issues. Tested locally to ensure no regressions.

---
*PR created automatically by Jules for task [13456968930418139164](https://jules.google.com/task/13456968930418139164) started by @TarasMazepa*